### PR TITLE
Add topic description feature

### DIFF
--- a/app/code/Magento/AsynchronousOperations/Model/TopicDescriptionPool.php
+++ b/app/code/Magento/AsynchronousOperations/Model/TopicDescriptionPool.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+declare(strict_types=1);
+
+namespace Magento\AsynchronousOperations\Model;
+
+/**
+ * Bulk operations description pool
+ */
+class TopicDescriptionPool
+{
+    /**
+     * @var array
+     */
+    private $descriptions;
+
+    /**
+     * BulkDescriptionPool constructor
+     *
+     * @param array $descriptions
+     */
+    public function __construct(
+        $descriptions = []
+    ) {
+        $this->descriptions = $descriptions;
+    }
+
+    /**
+     * Get description for a given topic name
+     *
+     * @param string $topicName
+     * @return string|null
+     */
+    public function getDescription($topicName)
+    {
+        if (isset($this->descriptions[$topicName])) {
+            return $this->descriptions[$topicName];
+        }
+
+        return null;
+    }
+}

--- a/app/code/Magento/AsynchronousOperations/Test/Unit/Model/TopicDescriptionPoolTest.php
+++ b/app/code/Magento/AsynchronousOperations/Test/Unit/Model/TopicDescriptionPoolTest.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+
+namespace Magento\AsynchronousOperations\Test\Unit\Model;
+
+use Magento\AsynchronousOperations\Model\TopicDescriptionPool;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+
+/**
+ * Class StatusMapperTest
+ */
+class TopicDescriptionPoolTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @var \Magento\AsynchronousOperations\Model\TopicDescriptionPool
+     */
+    private $topicDescriptionPool;
+
+    /**
+     * @var array
+     */
+    private $testTopics = [
+        'async.V1.test.topic1' => 'Test topic 1',
+        'async.V1.test.topic2' => 'Test topic 2',
+        'async.V1.test.topic3' => 'Test topic 3',
+    ];
+
+    protected function setUp()
+    {
+        $this->topicDescriptionPool = (new ObjectManager($this))->getObject(
+            TopicDescriptionPool::class,
+            [
+                'descriptions' => $this->testTopics
+            ]
+        );
+    }
+
+    public function testGetDescriptionOnExistingValues()
+    {
+        foreach ($this->testTopics as $topic => $description) {
+            self::assertEquals($description, $this->topicDescriptionPool->getDescription($topic));
+        }
+    }
+
+    public function testGetDescriptionOnNonExistingValue()
+    {
+        self::assertNull($this->topicDescriptionPool->getDescription('non.existing.topic'));
+    }
+}


### PR DESCRIPTION
This PR adds the ability to define a topic name both via `\Magento\AsynchronousOperations\Model\MassSchedule::publishMass` parameter and di injection.

This will avoid to expose obscure messages from the user's perspective in the Magento backend when an async task is completed.

Currently we get messages like:

<img src="https://i.imgur.com/1zlb6Ha.png" />

While we should have something more user friendly like:

<img src="https://i.imgur.com/EU0fS8n.png" />
